### PR TITLE
feat: Goku poll gulag with exponential stacking

### DIFF
--- a/migrations/2026-03-12-000000_create_goku_poll_usage/down.sql
+++ b/migrations/2026-03-12-000000_create_goku_poll_usage/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE goku_poll_usage;

--- a/migrations/2026-03-12-000000_create_goku_poll_usage/up.sql
+++ b/migrations/2026-03-12-000000_create_goku_poll_usage/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE goku_poll_usage (
+    id SERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    guild_id BIGINT NOT NULL,
+    usage_count INTEGER NOT NULL DEFAULT 0,
+    last_goku_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE(user_id, guild_id)
+);

--- a/migrations/2026-03-12-000001_add_goku_poll_feature/down.sql
+++ b/migrations/2026-03-12-000001_add_goku_poll_feature/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM features WHERE name = 'goku_poll';

--- a/migrations/2026-03-12-000001_add_goku_poll_feature/up.sql
+++ b/migrations/2026-03-12-000001_add_goku_poll_feature/up.sql
@@ -1,0 +1,2 @@
+INSERT INTO features (name, enabled) VALUES ('goku_poll', true)
+ON CONFLICT (name) DO NOTHING;

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -4,11 +4,12 @@ pub mod schema;
 
 use self::{
     models::{
-        AiSlopUsage, GulagUser, GulagVote, NewAiSlopUsage, NewGulagUser, NewGulagVote, NewServer,
-        Server,
+        AiSlopUsage, GokuPollUsage, GulagUser, GulagVote, NewAiSlopUsage, NewGokuPollUsage,
+        NewGulagUser, NewGulagVote, NewServer, Server,
     },
     schema::{
         ai_slop_usage::{self},
+        goku_poll_usage::{self},
         gulag_users::{self},
         gulag_votes::{self},
         servers,
@@ -236,6 +237,67 @@ pub fn atomic_increment_ai_slop(
         .set((
             usage_count.eq(usage_count + 1),
             last_slop_at.eq(time_now),
+        ))
+        .get_result(&mut conn)?;
+
+    Ok(result.usage_count)
+}
+
+pub fn get_or_create_goku_poll_usage(
+    pool: &DbPool,
+    target_user_id: i64,
+    target_guild_id: i64,
+) -> Result<GokuPollUsage, diesel::result::Error> {
+    let mut conn = pool.get().map_err(pool_error_to_diesel)?;
+    use self::goku_poll_usage::dsl::*;
+
+    match goku_poll_usage
+        .filter(user_id.eq(target_user_id))
+        .filter(guild_id.eq(target_guild_id))
+        .first::<GokuPollUsage>(&mut conn)
+    {
+        Ok(usage) => Ok(usage),
+        Err(diesel::result::Error::NotFound) => {
+            let new_usage = NewGokuPollUsage {
+                user_id: target_user_id,
+                guild_id: target_guild_id,
+                usage_count: 0,
+                last_goku_at: SystemTime::now(),
+                created_at: SystemTime::now(),
+            };
+
+            diesel::insert_into(goku_poll_usage)
+                .values(&new_usage)
+                .get_result(&mut conn)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+pub fn atomic_increment_goku_poll(
+    pool: &DbPool,
+    target_user_id: i64,
+    target_guild_id: i64,
+) -> Result<i32, diesel::result::Error> {
+    let mut conn = pool.get().map_err(pool_error_to_diesel)?;
+    use self::goku_poll_usage::dsl::*;
+
+    let time_now = SystemTime::now();
+    let new_record = NewGokuPollUsage {
+        user_id: target_user_id,
+        guild_id: target_guild_id,
+        usage_count: 1,
+        last_goku_at: time_now,
+        created_at: time_now,
+    };
+
+    let result: GokuPollUsage = diesel::insert_into(goku_poll_usage)
+        .values(&new_record)
+        .on_conflict((user_id, guild_id))
+        .do_update()
+        .set((
+            usage_count.eq(usage_count + 1),
+            last_goku_at.eq(time_now),
         ))
         .get_result(&mut conn)?;
 

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -28,6 +28,27 @@ pub struct NewAiSlopUsage {
     pub created_at: SystemTime,
 }
 
+#[derive(Queryable, Selectable, Debug)]
+#[diesel(table_name = goku_poll_usage)]
+pub struct GokuPollUsage {
+    pub id: i32,
+    pub user_id: i64,
+    pub guild_id: i64,
+    pub usage_count: i32,
+    pub last_goku_at: SystemTime,
+    pub created_at: SystemTime,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = goku_poll_usage)]
+pub struct NewGokuPollUsage {
+    pub user_id: i64,
+    pub guild_id: i64,
+    pub usage_count: i32,
+    pub last_goku_at: SystemTime,
+    pub created_at: SystemTime,
+}
+
 #[derive(Queryable)]
 pub struct Server {
     pub id: i32,

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -27,6 +27,17 @@ diesel::table! {
 }
 
 diesel::table! {
+    goku_poll_usage (id) {
+        id -> Int4,
+        user_id -> Int8,
+        guild_id -> Int8,
+        usage_count -> Int4,
+        last_goku_at -> Timestamp,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     gulag_users (id) {
         id -> Int4,
         user_id -> Int8,
@@ -90,6 +101,7 @@ diesel::table! {
 diesel::allow_tables_to_appear_in_same_query!(
     ai_slop_usage,
     features,
+    goku_poll_usage,
     gulag_users,
     gulag_votes,
     message_votes,

--- a/src/handlers/goku_poll.rs
+++ b/src/handlers/goku_poll.rs
@@ -1,0 +1,188 @@
+use super::get_pool;
+use crate::db::{atomic_increment_goku_poll, get_or_create_goku_poll_usage, get_server_by_guild_id};
+use crate::features::Features;
+use crate::handlers::gulag::Gulag;
+use serenity::{
+    all::{CreateMessage, Mentionable},
+    client::Context,
+    model::channel::Message,
+};
+
+pub struct GokuPoll;
+
+impl GokuPoll {
+    const MAX_DURATION_SECS: u32 = 2_592_000; // 30 days in seconds
+
+    pub async fn handle_message_update(ctx: &Context, message: &Message) {
+        let poll = match &message.poll {
+            Some(p) => p,
+            None => return,
+        };
+
+        // Only process finalized polls
+        let results = match &poll.results {
+            Some(r) if r.is_finalized => r,
+            _ => return,
+        };
+
+        let guild_id = match message.guild_id {
+            Some(id) => id.get(),
+            None => return,
+        };
+
+        let pool = get_pool(ctx).await;
+
+        if !Features::is_enabled(&pool, "goku_poll") {
+            return;
+        }
+
+        // Find the winning answer (highest vote count)
+        let winning_answer = match results.answer_counts.iter().max_by_key(|a| a.count) {
+            Some(a) if a.count > 0 => a,
+            _ => return, // No votes cast
+        };
+
+        // Look up the answer text from the poll answers
+        let winning_text = match poll
+            .answers
+            .iter()
+            .find(|a| a.answer_id == winning_answer.id)
+        {
+            Some(answer) => match &answer.poll_media.text {
+                Some(text) => text.clone(),
+                None => return,
+            },
+            None => return,
+        };
+
+        // Check if the winning answer contains "goku" (case-insensitive)
+        if !winning_text.to_lowercase().contains("goku") {
+            return;
+        }
+
+        let poll_creator = &message.author;
+
+        // Don't gulag the bot
+        match Gulag::is_tugbot(&ctx.http, poll_creator).await {
+            Some(true) | None => return,
+            Some(false) => {}
+        }
+
+        let server = match get_server_by_guild_id(&pool, guild_id as i64) {
+            Some(s) => s,
+            None => {
+                eprintln!("Goku poll: server not configured for guild {}", guild_id);
+                return;
+            }
+        };
+
+        // Get current usage count for exponential duration
+        let current_count =
+            match get_or_create_goku_poll_usage(&pool, poll_creator.id.get() as i64, guild_id as i64)
+            {
+                Ok(u) => u.usage_count,
+                Err(e) => {
+                    eprintln!("Goku poll: failed to get usage count: {}", e);
+                    return;
+                }
+            };
+
+        let duration_seconds = Self::calculate_duration(current_count);
+
+        // Find a channel to post in - use the-gulag channel
+        let gulag_channel =
+            match Gulag::find_channel(&ctx.http, guild_id, "the-gulag".to_string()).await {
+                Some(c) => c,
+                None => {
+                    eprintln!("Goku poll: could not find the-gulag channel");
+                    return;
+                }
+            };
+
+        // Send to gulag
+        if let Err(e) = Gulag::add_to_gulag(
+            &ctx.http,
+            &pool,
+            crate::handlers::gulag::GulagParams {
+                guildid: guild_id,
+                userid: poll_creator.id.get(),
+                gulag_roleid: server.gulag_id as u64,
+                gulaglength: duration_seconds,
+                channelid: gulag_channel.id.get(),
+                messageid: message.id.get(),
+            },
+        )
+        .await
+        {
+            eprintln!("Goku poll: failed to send user to gulag: {}", e);
+            return;
+        }
+
+        // Increment usage count after successful gulag
+        let new_count =
+            match atomic_increment_goku_poll(&pool, poll_creator.id.get() as i64, guild_id as i64) {
+                Ok(count) => count,
+                Err(e) => {
+                    eprintln!("Goku poll: failed to increment usage count: {}", e);
+                    current_count + 1
+                }
+            };
+
+        let next_duration_seconds = Self::calculate_duration(new_count);
+
+        let content = format!(
+            "{} created a poll and Goku won. Sent to the gulag for {}!\nThis is offense #{} (next offense will be {})",
+            poll_creator.mention(),
+            Self::format_duration(duration_seconds),
+            new_count,
+            Self::format_duration(next_duration_seconds),
+        );
+
+        let _ = gulag_channel
+            .send_message(&ctx.http, CreateMessage::new().content(content))
+            .await;
+    }
+
+    fn calculate_duration(usage_count: i32) -> u32 {
+        // Same formula as AI slop: 1800 * 2^usage_count seconds
+        // First offense (count=0): 30 minutes
+        // Second offense (count=1): 60 minutes
+        // Third offense (count=2): 120 minutes
+        // Capped at MAX_DURATION_SECS
+
+        let base_seconds: u64 = 1800; // 30 minutes
+
+        let multiplier = match usage_count.try_into() {
+            Ok(count) if count < 32 => 2u64.checked_pow(count).unwrap_or(u64::MAX),
+            _ => u64::MAX,
+        };
+
+        let duration = base_seconds.saturating_mul(multiplier);
+
+        duration.min(Self::MAX_DURATION_SECS as u64) as u32
+    }
+
+    fn format_duration(seconds: u32) -> String {
+        let minutes = seconds / 60;
+        let hours = minutes / 60;
+        let days = hours / 24;
+        let remaining_hours = hours % 24;
+        let remaining_minutes = minutes % 60;
+
+        if days > 0 {
+            if remaining_hours > 0 {
+                format!("{} days {} hours", days, remaining_hours)
+            } else {
+                format!("{} days", days)
+            }
+        } else if hours > 0 {
+            if remaining_minutes > 0 {
+                format!("{} hours {} minutes", hours, remaining_minutes)
+            } else {
+                format!("{} hours", hours)
+            }
+        } else {
+            format!("{} minutes", minutes)
+        }
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -4,6 +4,7 @@ pub mod bsky;
 pub mod derpies;
 pub mod elon;
 pub mod feat;
+pub mod goku_poll;
 pub mod gulag;
 pub mod horny;
 pub mod instagram;
@@ -35,6 +36,7 @@ use crate::handlers::{
     ai_slop::AiSlopHandler,
     bsky::Bsky,
     feat::Feat,
+    goku_poll::GokuPoll,
     gulag::{
         gulag_handler::GulagHandler,
         gulag_list_handler::GulagListHandler,
@@ -51,7 +53,7 @@ use crate::handlers::{
 use crate::tugbot::servers::Servers;
 use instagram::Instagram;
 use serenity::{
-    all::{Interaction, Member, Message, Reaction, Ready},
+    all::{Interaction, Member, Message, MessageUpdateEvent, Reaction, Ready},
     async_trait,
     builder::{CreateInteractionResponse, CreateInteractionResponseMessage, CreateMessage},
     client::{Context, EventHandler},
@@ -82,6 +84,34 @@ impl EventHandler for Handler {
 
     async fn reaction_remove(&self, ctx: Context, add_reaction: Reaction) {
         GulagReaction::handler(&ctx, &add_reaction, GulagReactionType::REMOVED).await;
+    }
+
+    async fn message_update(
+        &self,
+        ctx: Context,
+        _old_if_available: Option<Message>,
+        new: Option<Message>,
+        event: MessageUpdateEvent,
+    ) {
+        // Try to use the full message if available, otherwise fetch it
+        let message = match new {
+            Some(msg) => msg,
+            None => {
+                match ctx
+                    .http
+                    .get_message(event.channel_id, event.id)
+                    .await
+                {
+                    Ok(msg) => msg,
+                    Err(e) => {
+                        eprintln!("Failed to fetch message for update event: {}", e);
+                        return;
+                    }
+                }
+            }
+        };
+
+        GokuPoll::handle_message_update(&ctx, &message).await;
     }
 
     async fn guild_member_addition(&self, ctx: Context, member: Member) {

--- a/src/tugbot/config.rs
+++ b/src/tugbot/config.rs
@@ -23,7 +23,8 @@ impl Config {
 
         let intents = GatewayIntents::privileged()
             .union(GatewayIntents::GUILD_MESSAGES)
-            .union(GatewayIntents::GUILD_MESSAGE_REACTIONS);
+            .union(GatewayIntents::GUILD_MESSAGE_REACTIONS)
+            .union(GatewayIntents::GUILD_MESSAGE_POLLS);
         Config {
             db_url,
             token,


### PR DESCRIPTION
## Summary
- When a Discord poll concludes and the winning answer contains "goku" (case-insensitive), the poll creator is automatically sent to the gulag
- Duration uses the same exponential doubling as AI slop: 30min base, doubling each offense (60min, 2hr, 4hr, ...), capped at 30 days
- Per-user offense tracking via new `goku_poll_usage` database table
- Feature-flagged as `goku_poll` (enabled by default)
- Adds `GUILD_MESSAGE_POLLS` gateway intent to receive poll events

## Test plan
- [ ] Create a poll with a "goku" answer option and let it conclude with goku winning
- [ ] Verify poll creator is sent to gulag for 30 minutes on first offense
- [ ] Repeat and verify duration doubles to 60 minutes
- [ ] Verify non-goku poll winners don't trigger gulag
- [ ] Verify feature flag `goku_poll` can disable the feature
- [ ] Verify stacking works when user is already in gulag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Enabled "Goku Poll" feature that monitors polls and tracks outcomes containing "goku" in winning answers per user and server.
* Implemented escalating response mechanism with exponentially increasing durations for repeated occurrences, capped at 30 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->